### PR TITLE
ci: inject ISSUES_PAT secret into index.html at deploy time

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,6 +21,12 @@ jobs:
       - name: Validate index.html exists
         run: test -s index.html || (echo "index.html missing or empty" && exit 1)
 
+      - name: Inject PAT into index.html
+        run: |
+          sed -i "s|REPLACE_WITH_YOUR_PAT|${{ secrets.ISSUES_PAT }}|g" index.html
+        # The ISSUES_PAT secret is stored in repo Settings → Secrets → Actions.
+        # It never appears in source — only in the deployed gh-pages build.
+
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4
         with:


### PR DESCRIPTION
Store PAT in repo secret ISSUES_PAT. The deploy workflow substitutes the placeholder in index.html before publishing to gh-pages. Source stays clean.